### PR TITLE
Config Override Possibility

### DIFF
--- a/snippetssync/ext.snippetssync.php
+++ b/snippetssync/ext.snippetssync.php
@@ -16,7 +16,7 @@ class Snippetssync_ext extends Ab_ExtBase {
     public $settings        = array();
 
     public $name            = 'SnippetsSync';
-    public $version         = '1.0.1';
+    public $version         = '1.0.2';
     public $description     = 'Enables you to work with snippets & global variables as files while developing';
     public $settings_exist  = 'n';
     public $docs_url        = 'http://ee.bybjorn.com/snippetssync';
@@ -55,7 +55,7 @@ class Snippetssync_ext extends Ab_ExtBase {
     public function on_sessions_start($ref)
     {
         $this->EE->load->config('snippetssync');
-        if(!$this->EE->config->item('snippetssync_production_mode'))
+        if(!$this->EE->config->item('snippetssync_production_mode_override') && !$this->EE->config->item('snippetssync_production_mode'))
         {
             $this->EE->load->library('snippetslib');
             $success = $this->EE->snippetslib->sync_all();

--- a/snippetssync/upd.snippetssync.php
+++ b/snippetssync/upd.snippetssync.php
@@ -13,7 +13,7 @@
  */
 class Snippetssync_upd {
 		
-	var $version        = '1.0.1';
+	var $version        = '1.0.2';
 	var $module_name = "Snippetssync";
 	
     function Snippetssync_upd( $switch = TRUE ) 


### PR DESCRIPTION
Hi Bjørn,

We're using snippetsync on a site (thanks!) and I found a need to trigger "Production Mode" automatically without modifying the add-on's config file. I ever-so-slightly altered the Extension file to check for a config.php value so we could achieve this.

Feel free to merge or ignore the change. I thought I'd send it your way regardless.

Cheers,
Erik
# 

Added the ability to trigger "Production Mode" without altering the add-on config file.
Now I can trigger production mode in a config.php override based on my environment (automatically)

$config['snippetssync_production_mode_override'] = TRUE;

Bumped version up to 1.0.2
# 
