### PR TITLE
Folders now settable via config.php + Auto create folders + Sanitize filenames.

### DIFF
--- a/snippetssync/libraries/snippetslib.php
+++ b/snippetssync/libraries/snippetslib.php
@@ -88,16 +88,28 @@ class Snippetslib extends Ab_LibBase {
 
 			$global_variables = $this->get_files($this->gv_path);
 			$snippets = $this->get_files($this->sn_path);
+			
+			// regex arrays, used to create valid snippet and global variable names.
+			$search = array(
+				"/\..*$/ui", //strips extension.
+				"/([^a-zA-Z0-9\-\_]+)/i", // remove illegal chars
+				"/(^[\.\-\_]*|[\.\-\_]*$)/i"
+			);
+			$replace= array(
+				"", // replace extension with nothing
+				"_", // replace illegal chars with an underscore
+				"" // if we end up with a special char at the end or beginning of the name remove this char.
+			);
 
 			foreach($global_variables as $global_variable_filename)
 			{
-				$global_variable_name = str_replace('.html', '', $global_variable_filename);
-
+				$global_variable_name = preg_replace( $search , $replace , $global_variable_filename );
+				
 				$this->EE->db->where('variable_name', $global_variable_name);
 				$this->EE->db->from('global_variables');
 				
 				$global_variable_data = file_get_contents($this->gv_path.$global_variable_filename);
-
+				
 				if($this->EE->db->count_all_results() == 0)
 				{
 					$this->EE->db->insert('global_variables', array(
@@ -110,13 +122,13 @@ class Snippetslib extends Ab_LibBase {
 					$this->EE->db->where('variable_name', $global_variable_name);
 					$this->EE->db->update('global_variables', array('variable_data' => $global_variable_data));
 				}
-
+				
 				$this->last_sync_log['globals'][] = $global_variable_name;
 			}
 
 			foreach($snippets as $snippet_filename)
 			{
-				$snippet_name = str_replace('.html', '', $snippet_filename);
+				$snippet_name = preg_replace( $search , $replace , $snippet_filename );
 
 				$this->EE->db->where('snippet_name', $snippet_name);
 				$this->EE->db->from('snippets');


### PR DESCRIPTION
- Folder names can now be set via $['config'] as "snippetssync_sn_folder" and "snippetssync_gv_folder" respectively. _(the fallbacks of 'snippets/' and 'global_variables/' remain if no folder is otherwise specified.)_
- Added automatic creation of snippets & global_variables folders if they don't exist. _(If the designated folders don't exist yet, the script creates them if it can get write permissions to the folder.)_
- Any file extension can now be used (if any). _(As opposed to be confined to .html. Some might like to use .snip or .gvar or something…)_
- Filename is now being sanitized to allow only `a-zA-Z0-9-_` as per the requirements of global vars and snippets in EE. _(Previously it was possible (and write this to the DB) to create filenames that would result in illegally named global variables or snippets.)_
## Note!

**Please** check my code, I did test everything but I wrote all this after only having just learned PHP + CI in the last 5 days. If stuff is not quite right I would appreciate you telling me what I have done wrong so I can do better next time.
