### PR TITLE
Sync hook

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,11 @@ Changelog for SnippetsSync
 ==========================
 The dates in this changelog use international date format: YYYY-MM-DD (ISO8601)
 
+1.2 - 2015-03-03
+------------------
+* Feature: Generate unique URL to run SnippetsSync over HTTP. Use case – post-deploy hook. Also returns JSON response via AJAX call. (@elliotlewis)
+* Bug fix: mk_perms, even on successful creation of folder, error logged in CP.
+
 1.1.4 - 2014-08-06
 ------------------
 * SnippetsSync donesn't check for 'save_tmpl_files' anymore. The reason for this is that one might not want to save templates as files on production, and still be able to have snippetssync installed and sync manually ((without it throwing an error) - see https://github.com/bjornbjorn/snippetssync.ee2_addon/issues/13

--- a/system/expressionengine/third_party/snippetssync/config/snippetssync.php
+++ b/system/expressionengine/third_party/snippetssync/config/snippetssync.php
@@ -6,7 +6,8 @@
  * in addons-> modules -> snippetssync you can click to do a manual sync.
  */
 $config['snippetssync_production_mode'] = FALSE;
-$config['snippetssync_snippet_prefix'] = '';                    // for example: 'sn_'
-$config['snippetssync_global_variable_prefix'] = '';            // for example: 'gv_'
+$config['snippetssync_snippet_prefix'] = '';            // for example: 'sn_'
+$config['snippetssync_global_variable_prefix'] = '';    // for example: 'gv_'
+$config['snippetssync_sync_var'] = 'CHANGEME';	    	// any random string to pass through on a URL sync
 
 // NOTE: if you set these variables in your master config those will be used instead of these :-)

--- a/system/expressionengine/third_party/snippetssync/ext.snippetssync.php
+++ b/system/expressionengine/third_party/snippetssync/ext.snippetssync.php
@@ -18,7 +18,7 @@ class Snippetssync_ext extends Ab_ExtBase {
     public $settings        = array();
 
     public $name            = 'SnippetsSync';
-    public $version         = '1.1.4';
+    public $version         = '1.2';
     public $description     = 'Enables you to work with snippets & global variables as files while developing';
     public $settings_exist  = 'n';
     public $docs_url        = 'http://ee.bybjorn.com/snippetssync';

--- a/system/expressionengine/third_party/snippetssync/language/english/snippetssync_lang.php
+++ b/system/expressionengine/third_party/snippetssync/language/english/snippetssync_lang.php
@@ -6,3 +6,4 @@ $lang['snippetssync_welcome'] = 'Welcome to SnippetsSync';
 $lang['snippetssync_manually'] = 'Sync Manually';
 $lang['snippetssync_again'] = 'Do It Again!';
 $lang['snippetssync_synced'] = 'Global Variables & Snippets Synced';
+$lang['snippetssync_sync_url'] = 'Unique Sync URL';

--- a/system/expressionengine/third_party/snippetssync/libraries/snippetslib.php
+++ b/system/expressionengine/third_party/snippetssync/libraries/snippetslib.php
@@ -238,10 +238,14 @@ class Snippetslib extends Ab_LibBase {
 
         if ( octdec(substr(sprintf('%o', @fileperms( $dir )), -4)) < $perms )
 		{
-			@chmod( $dir , $perms );
-		}
-		else {
-			return FALSE;
+			if( chmod( $dir , $perms ) )
+			{
+				return TRUE;
+			}
+			else
+			{
+				return FALSE;
+			}
 		}
 
 		return TRUE;

--- a/system/expressionengine/third_party/snippetssync/mcp.snippetssync.php
+++ b/system/expressionengine/third_party/snippetssync/mcp.snippetssync.php
@@ -35,9 +35,13 @@ class Snippetssync_mcp
 
 	public function index()
 	{
+		$snippetssync_sync_var = $this->EE->config->item('snippetssync_sync_var');
+		
         // snippetssync_production_mode_override for backwards compatibility
 		$vars = array(
-            'production_mode' => $this->EE->config->item('snippetssync_production_mode_override') || $this->EE->config->item('snippetssync_production_mode'),
+            'production_mode'	=> $this->EE->config->item('snippetssync_production_mode_override') || $this->EE->config->item('snippetssync_production_mode'),
+			'sync_var'			=> $snippetssync_sync_var,
+            'sync_url'			=> $this->EE->functions->fetch_site_index(0, 0).QUERY_MARKER.'ACT='.$this->EE->cp->fetch_action_id($this->module_name, 'url_sync').'&sync='.$snippetssync_sync_var,
         );
 		return $this->content_wrapper('index', 'snippetssync_welcome', $vars);
 	}

--- a/system/expressionengine/third_party/snippetssync/mod.snippetssync.php
+++ b/system/expressionengine/third_party/snippetssync/mod.snippetssync.php
@@ -1,0 +1,98 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/**
+ * SnippetsSync
+ *
+ * @package		extended_forum_tags
+ * @subpackage	ThirdParty
+ * @category	Extension
+ * @author		Bjorn Borresen / Elliot Lewis
+ * @link		http://ee.bybjorn.com/eft
+ */
+
+class Snippetssync {
+
+	var $module_name	= "Snippetssync";
+	var $return_data	= '';
+	
+	public function Snippetssync()
+	{
+		// Make a local reference to the ExpressionEngine super object
+		$this->EE =& get_instance();
+	}
+	
+	public function url_sync()
+	{
+
+		$output		= '';
+		$ajax_output= [];
+		
+		$ajax		= FALSE;
+		if( !empty( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest') $ajax = TRUE;
+		
+		// Check for unique var in URL, error if not present
+		// Check if matches config, error if not
+		$snippetssync_sync_var	= $this->EE->config->item('snippetssync_sync_var');
+		$sync_var				= $this->EE->input->get('sync', TRUE);
+
+		if (!$sync_var || $sync_var == '' || $sync_var == 'CHANGEME' || $sync_var != $snippetssync_sync_var)
+		{
+			if ($ajax)
+			{
+				$ajax_output['success'] = FALSE;
+				$ajax_output['error'] = 'URL incorrect, check the config folder in '.$this->module_name.'.';
+				echo json_encode($ajax_output);
+				exit;
+			}
+			else
+			{
+				$this->EE->output->show_user_error('submission', 'Check the <b>config</b> folder in '.$this->module_name.'.', 'Unique URL error');
+			}
+		}
+		else
+		{
+			// run sync
+			$this->EE->load->library('snippetslib');
+			$success = $this->EE->snippetslib->sync_all();
+
+			if(!$success)
+			{
+				if ($ajax)
+				{
+					$ajax_output['success'] = FALSE;
+					$ajax_output['error'] = 'Sync failed: ' . $this->EE->snippetslib->error_message;
+					echo json_encode($ajax_output);
+					exit;
+				}
+				else
+				{
+					$this->EE->output->show_user_error('submission', 'Sync failed: ' . $this->EE->snippetslib->error_message, 'Sync error');
+				}
+			}
+			else
+			{
+				if ($ajax)
+				{
+					$ajax_output['success'] = TRUE;
+					echo json_encode($ajax_output);
+					exit;
+				}
+				else
+				{
+					$this->EE->output->show_message(
+					array(
+						'title'		=> $this->module_name,
+						'heading'	=> 'Snippets Sync via URL',
+						'content'	=> 'Success'
+						)
+					);
+				}
+			}
+		}
+
+		return $output;
+	}
+
+}
+/* End of file mod.snippetssync.php */
+/* Location: ./system/expressionengine/third_party/download/mod.snippetssync.php */

--- a/system/expressionengine/third_party/snippetssync/upd.snippetssync.php
+++ b/system/expressionengine/third_party/snippetssync/upd.snippetssync.php
@@ -13,7 +13,7 @@
  */
 class Snippetssync_upd {
 
-	var $version        = '1.1.4';
+	var $version        = '1.2';
 	var $module_name = "Snippetssync";
 
     function Snippetssync_upd( $switch = TRUE )
@@ -35,10 +35,11 @@ class Snippetssync_upd {
 		);
 
 		$this->EE->db->insert('modules', $data);
-
-		//
-		// Add additional stuff needed on module install here
-		//
+		
+		$this->EE->db->insert('actions', array(
+			'class'		=> $this->module_name,
+			'method'	=> 'url_sync'
+		));
 
 		return TRUE;
 	}
@@ -80,6 +81,14 @@ class Snippetssync_upd {
         if ($current < '1.0.8') {
             $this->EE->db->delete('extensions', array('class' => 'Snippetssync_ext', 'method' => 'on_cp_js_end'));
         }
+        
+        if ($current < '1.2')
+        {
+	        $this->EE->db->insert('actions', array(
+				'class'		=> $this->module_name,
+				'method'	=> 'url_sync'
+			));
+		}
 
         return TRUE;
 	}

--- a/system/expressionengine/third_party/snippetssync/views/index.php
+++ b/system/expressionengine/third_party/snippetssync/views/index.php
@@ -19,3 +19,27 @@
         <?php echo form_submit('submit',lang('snippetssync_manually'),'class="submit"')?>
     <?php echo form_close()?>
 </p>
+
+<h3 style="margin-top: 30px;">Sync via URL</h3>
+
+<p>Unique URL when sync&rsquo;ing over HTTP.</p>
+<p>This can be used as a post-deploy hook to sync snippets on a production server.</p>
+
+<?php if ($sync_var == '' || $sync_var == 'CHANGEME') : ?>
+
+	<p>Please change &lsquo;<b>snippetssync_sync_var</b>&rsquo; in <em>config/snippetssync.php</em> to generate a unique URL.</p>
+
+<?php else : ?>
+
+	<p>
+	<?php
+		$input_data = 'sync_url';
+		$input_value = $sync_url;
+	
+		echo lang('snippetssync_sync_url', 'sync_url');
+	
+		echo form_input($input_data, $input_value, 'id="sync_url"' );
+	?>
+	</p>
+
+<?php endif; ?>


### PR DESCRIPTION
* Feature: Generate unique URL to run SnippetsSync over HTTP. Use case
– post-deploy hook. Also returns JSON response via AJAX call.
(@elliotlewis)
* Bug fix: mk_perms, even on successful creation of folder, error
logged in CP.